### PR TITLE
fix title for education in leftNav

### DIFF
--- a/src/core/containers/LeftNav.tsx
+++ b/src/core/containers/LeftNav.tsx
@@ -48,7 +48,7 @@ const sideBarList = [
   },
   {
     key: 4,
-    title: 'Experience',
+    title: 'Education',
     icon: 'education',
     component: <EduEditor />,
   },


### PR DESCRIPTION
error: title for education was named as experience

#### Changes

to reproduce the error :  go to  https://sadanandpai.github.io/single-page-resume-builder/dist/
hover over the education icon , You can see that It is named as experience.
the fix :
![Screenshot (93)](https://user-images.githubusercontent.com/52914487/137862844-cf673972-60a1-42bc-a450-03fea5060476.png)


#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
